### PR TITLE
Add static site with dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# vibe_code_blog
+# Vibe Code Blog
+
+This repository contains a simple static blog that supports light and dark themes. You can view the blog locally or deploy it for free using GitHub Pages.
+
+## Development
+
+Open `index.html` in a browser to view the blog. The theme toggle button stores your preference in `localStorage` so it persists between visits.
+
+## Deployment
+
+1. Commit all changes to the `main` branch of your GitHub repository.
+2. In the repository settings on GitHub, enable **GitHub Pages** and select the `main` branch as the source.
+3. Your site will be available at `https://<username>.github.io/<repository>`.
+
+That's it! Modify or add posts in the `posts/` directory to update your blog.

--- a/about.html
+++ b/about.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>About - Vibe Code Blog</title>
+  <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+  <header>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <button id="theme-toggle">Toggle Theme</button>
+    </nav>
+  </header>
+  <main>
+    <h1>About</h1>
+    <p>This is a simple blog created as a demo. It supports light and dark themes.</p>
+  </main>
+  <footer>
+    <p>&copy; 2025 Vibe Code Blog</p>
+  </footer>
+  <script src="assets/js/theme-toggle.js"></script>
+</body>
+</html>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,31 @@
+/* Basic styles */
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  line-height: 1.6;
+  transition: background-color 0.3s, color 0.3s;
+}
+
+header, footer {
+  background-color: #f5f5f5;
+  padding: 1rem;
+}
+
+header nav a {
+  margin-right: 1rem;
+}
+
+main {
+  padding: 1rem;
+}
+
+/* Dark mode */
+body.dark {
+  background-color: #1a1a1a;
+  color: #eaeaea;
+}
+
+body.dark header, body.dark footer {
+  background-color: #333;
+}

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -1,0 +1,13 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.getElementById('theme-toggle');
+  const currentTheme = localStorage.getItem('theme');
+  if (currentTheme === 'dark') {
+    document.body.classList.add('dark');
+  }
+
+  toggle.addEventListener('click', () => {
+    document.body.classList.toggle('dark');
+    const theme = document.body.classList.contains('dark') ? 'dark' : 'light';
+    localStorage.setItem('theme', theme);
+  });
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Vibe Code Blog</title>
+  <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+  <header>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <button id="theme-toggle">Toggle Theme</button>
+    </nav>
+  </header>
+  <main>
+    <h1>Welcome to Vibe Code Blog</h1>
+    <p>Check out our latest posts:</p>
+    <ul>
+      <li><a href="posts/first-post.html">First Post</a></li>
+    </ul>
+  </main>
+  <footer>
+    <p>&copy; 2025 Vibe Code Blog</p>
+  </footer>
+  <script src="assets/js/theme-toggle.js"></script>
+</body>
+</html>

--- a/posts/first-post.html
+++ b/posts/first-post.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>First Post - Vibe Code Blog</title>
+  <link rel="stylesheet" href="../assets/css/styles.css">
+</head>
+<body>
+  <header>
+    <nav>
+      <a href="../index.html">Home</a>
+      <a href="../about.html">About</a>
+      <button id="theme-toggle">Toggle Theme</button>
+    </nav>
+  </header>
+  <main>
+    <h1>First Post</h1>
+    <p>Welcome to the first post on the Vibe Code Blog! This site is built with simple HTML, CSS, and JavaScript.</p>
+  </main>
+  <footer>
+    <p>&copy; 2025 Vibe Code Blog</p>
+  </footer>
+  <script src="../assets/js/theme-toggle.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple index, about, and first blog post
- implement dark/light theme switch with persistent setting
- provide basic styles
- document GitHub Pages deployment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847cdc7ec10832d8260c1e761afee34